### PR TITLE
Add setup.py to enable installation with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,12 @@ for changes see [Changelog](CHANGELOG.md)
  
 # Setup
 
- * Add FNFTpy folder to your Python path.
+ * From within the project root folder
+     ```
+     pip install .     # Install system wide
+     pip install -e .  # Install in editable/development mode
+     ```
+
  * Of course, you need a compiled version of the FNFT C-library. See the
   [documentation for FNFT](https://github.com/FastNFT/FNFT) on how to build 
    the library on your device. 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup, find_packages
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup(
+    name="FNFTpy",
+    version="0.1",
+    author="Christoph Mahnke",
+    author_email="",
+    description=("A python wrapper for FNFT, a C library to calculate the "
+                 "Nonlinear Fourier Transform listening skills "
+                 "while watching movies"),
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/xmhk/FNFTpy",
+    packages=find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+    ],
+    install_requires=[
+        "numpy"
+    ]
+)


### PR DESCRIPTION
Installing packages with pip is preferred over modifying PYTHONPATH, which sometimes does not play nice with conda environments.


